### PR TITLE
Add Loop Gateway to Cost-first multi-model section

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Stars auto-refresh daily. ✅ built-in · ➕ via plugin/paid tier · ❌ not av
 - [Eden AI](https://www.edenai.co) — Unified API for 500+ models plus vision/OCR/speech; EU-based, ~5.5% platform fee.
 - [Helicone AI Gateway (cloud)](https://www.helicone.ai) — Passthrough billing at **0% markup** with observability bundled.
 - [GPT-Load](https://github.com/tbphp/gpt-load) <!--s:tbphp/gpt-load-->⭐ 6.2k<!--/s--> — High-performance Go proxy that rotates pools of API keys across channels to maximize quota usage.
+- [Loop Gateway](https://github.com/Loop-XXI/loop-gateway) — OpenAI-compatible proxy that meters every request in Bitcoin sats instead of dollars. 311 models via OpenRouter at a 15% markup. No accounts, no email, no card; top up over Lightning, get a bearer token. Three auth rails (prepaid bearer, L402, Cashu). Self-hostable in Go via docker-compose, live at [api.loopxxi.com](https://api.loopxxi.com).
 
 > 💡 Squeeze more from any gateway: enable **semantic caching** (Kong, Bifrost, Zuplo), set **spend limits** (Cloudflare, Zuplo, Pydantic/Logfire), and route easy prompts to cheap models (see [Smart routing](#-smart-routing--model-selection)).
 


### PR DESCRIPTION
Adds [Loop Gateway](https://github.com/Loop-XXI/loop-gateway) to the **Cost-first: cheapest multi-model access** section.

**The unique angle for this list:** every gateway listed today bills in dollars. Loop Gateway meters every request in Bitcoin sats. For users who want zero account overhead, no card on file, and pay-per-request granularity down to single sats, that's a distinct pain point worth listing alongside the dollar-denominated options.

**What it is:** OpenAI-compatible LLM API. 311 models routed through OpenRouter at a 15% markup over upstream USD cost. No accounts, no email, no KYC, no card. Top up over Lightning, get a bearer token, use it like an OpenAI key.

**Highlights:**
- Three auth rails: prepaid bearer (simplest), L402 (HTTP 402 + macaroon), Cashu (Authorization or X-Cashu, NUT-24)
- OpenAI-compatible `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, streaming with token-accurate cost reconciliation
- 3-source median BTC price feed (Kraken, Coinbase, CoinGecko), 60s cache
- Encrypted per-account data vault (AES-256-GCM) and a Lightning-settled marketplace for selling vault shares
- Self-hostable in Go via docker-compose; phoenixd as the LN node
- MIT licensed

Quick test of the live L402 challenge, no payment needed:
```bash
curl -X POST https://api.loopxxi.com/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
```

You get back an HTTP 402 with a real phoenixd BOLT11 invoice and an L402 macaroon header.