### PR TITLE
Add FlintAPI — PPU-powered AI gateway (cheaper OpenRouter alternative)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Stars auto-refresh daily. ✅ built-in · ➕ via plugin/paid tier · ❌ not av
 - [Loop Gateway](https://github.com/Loop-XXI/loop-gateway) — OpenAI-compatible proxy that meters every request in Bitcoin sats instead of dollars. 311 models via OpenRouter at a 15% markup. No accounts, no email, no card; top up over Lightning, get a bearer token. Three auth rails (prepaid bearer, L402, Cashu). Self-hostable in Go via docker-compose, live at [api.loopxxi.com](https://api.loopxxi.com).
 - [AIMLAPI](https://aimlapi.com) — One OpenAI/Anthropic-compatible endpoint fronting 400+ models (chat, image, video, audio, embeddings); prepaid, OpenRouter-style aggregator.
 - [Novita AI](https://novita.ai) — Unified API to 200+ open-source models (DeepSeek/Qwen/Llama…) with load balancing, autoscaling and failover; also a GPU cloud.
+- [FlintAPI](https://flintapi.ai) — Self-hosted Qwen2.5-72B on custom PPU silicon, ~30% cheaper than OpenRouter; OpenAI-compatible API, $2 free credit on signup, referral rewards.
 - [Glama Gateway](https://glama.ai/ai/gateway) — OpenAI-compatible gateway to 100+ models with consolidated billing, caching and logging (OSS core [glama-ai/lightport](https://github.com/glama-ai/lightport)).
 
 > 💡 Squeeze more from any gateway: enable **semantic caching** (Kong, Bifrost, Zuplo), set **spend limits** (Cloudflare, Zuplo, Pydantic/Logfire), and route easy prompts to cheap models (see [Smart routing](#-smart-routing--model-selection)).


### PR DESCRIPTION
## Add FlintAPI to Cost-first section

[FlintAPI](https://flintapi.ai) is an AI model gateway running **Qwen2.5-72B on custom PPU silicon**, offering:
- ~30% lower cost than OpenRouter for Qwen models
- OpenAI-compatible API (drop-in replacement)
- $2 free credit on signup
- Referral rewards for community growth
- Self-hosted inference on 16x PPU-ZW810E cards

Would be a great addition to the Cost-first section alongside other OpenRouter alternatives.