### PR TITLE
Add lxg2it ModelRouter — free tier, $1 paid, 0% Anthropic markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Stars auto-refresh daily. ✅ built-in · ➕ via plugin/paid tier · ❌ not av
 | [OpenRouter](https://openrouter.ai) | SaaS marketplace | — | Commercial | ✅ 400+ | ✅ | ✅ | ➕ | ✅ |
 | [Vercel AI Gateway](https://vercel.com/ai-gateway) | SaaS (0% markup) | — | Commercial | ✅ 100s | ✅ | ❌ | ❌ | ✅ |
 | [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) | SaaS control plane | — | Commercial (free tier) | ✅ | ✅ dynamic | ✅ | ✅ | ✅ budgets |
-| [lxg2it ModelRouter](https://github.com/lxg2it/modelrouter-core) | OSS router + SaaS | <!--s:lxg2it/modelrouter-core-->⭐ 0<!--/s--> | MIT | ✅ 7+ | ✅ tiered fallback | ➕ | ❌ | ✅ |
+| [lxg2it ModelRouter](https://lxg2it.com) | OSS router + SaaS | <!--s:lxg2it/modelrouter-core-->⭐ 0<!--/s--> | MIT | ✅ 7+ | ✅ tiered fallback | ➕ | ❌ | ✅ |
 
 ¹ LiteLLM core is MIT; the repo contains a separately licensed enterprise directory.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ _Built the hard way: **I burned $788 on AI coding in a single day** — one flag
 |---|---|---|
 | Cheapest access to many models, zero ops | **OpenRouter** | [Cost-first](#-cost-first-cheapest-multi-model-access) |
 | Zero markup on my own keys | **Vercel** / **Cloudflare** | [Cost-first](#-cost-first-cheapest-multi-model-access) |
+| Free tier, $1 paid, cheapest Claude Opus | **lxg2it ModelRouter** | [Cost-first](#-cost-first-cheapest-multi-model-access) |
 | Self-host, broadest features | **LiteLLM** | [Self-hosted](#-self-hosted-open-source) |
 | Self-host, lowest overhead | **Bifrost** (Go) | [Self-hosted](#-self-hosted-open-source) |
 | China models + team key billing | **new-api** | [China ecosystem](#-china-ecosystem) |
@@ -57,7 +58,7 @@ _Built the hard way: **I burned $788 on AI coding in a single day** — one flag
 Do you want to self-host?
 │
 ├─ NO — hosted, minimal ops
-│   ├─ Cheapest access to many models ──────────▶ OpenRouter · Vercel AI Gateway (0% markup)
+│   ├─ Cheapest access to many models ──────────▶ OpenRouter · lxg2it ModelRouter · Vercel AI Gateway (0% markup)
 │   ├─ Free control plane over your own keys ───▶ Cloudflare AI Gateway
 │   ├─ EU data residency matters ───────────────▶ Requesty · Eden AI · nexos.ai
 │   └─ Already on one cloud ────────────────────▶ AWS Bedrock · Azure APIM · Vertex AI
@@ -109,6 +110,7 @@ Stars auto-refresh daily. ✅ built-in · ➕ via plugin/paid tier · ❌ not av
 | [OpenRouter](https://openrouter.ai) | SaaS marketplace | — | Commercial | ✅ 400+ | ✅ | ✅ | ➕ | ✅ |
 | [Vercel AI Gateway](https://vercel.com/ai-gateway) | SaaS (0% markup) | — | Commercial | ✅ 100s | ✅ | ❌ | ❌ | ✅ |
 | [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) | SaaS control plane | — | Commercial (free tier) | ✅ | ✅ dynamic | ✅ | ✅ | ✅ budgets |
+| [lxg2it ModelRouter](https://github.com/lxg2it/modelrouter-core) | OSS router + SaaS | <!--s:lxg2it/modelrouter-core-->⭐ 0<!--/s--> | MIT | ✅ 7+ | ✅ tiered fallback | ➕ | ❌ | ✅ |
 
 ¹ LiteLLM core is MIT; the repo contains a separately licensed enterprise directory.
 
@@ -127,6 +129,7 @@ Stars auto-refresh daily. ✅ built-in · ➕ via plugin/paid tier · ❌ not av
 - [OpenRouter](https://openrouter.ai) — The dominant model marketplace: 400+ models behind one OpenAI-compatible API, pay-as-you-go with automatic failover; ~5.5% fee when buying credits. $113M Series B (May 2026), ~8M users.
 - [Vercel AI Gateway](https://vercel.com/ai-gateway) — Hundreds of models at **provider list price (0% markup)**, $5/month free credits, zero-data-retention option; pairs naturally with the AI SDK.
 - [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) — Free control plane in front of your own provider keys: caching, dynamic routing, unified billing, and dollar-denominated spend limits (2026 beta).
+- [lxg2it ModelRouter](https://github.com/lxg2it/modelrouter-core) — Open-source, self-hostable model router with a hosted API at [api.lxg2it.com](https://api.lxg2it.com). Free tier, $1/month paid tier. 7+ providers (Anthropic, OpenAI, Google, Cerebras, Groq, Grok, GLM) behind one OpenAI-compatible API with **tiered automatic fallback** — define tiers by capability, router auto-selects cheapest available. **0% markup on Anthropic models** (cheapest hosted access to Claude Opus 4.8). No affiliate fees, no VC.
 - [Requesty](https://requesty.ai) — EU-friendly OpenRouter alternative: 400+ models, sub-20ms failover, ~5% markup.
 - [Eden AI](https://www.edenai.co) — Unified API for 500+ models plus vision/OCR/speech; EU-based, ~5.5% platform fee.
 - [Helicone AI Gateway (cloud)](https://www.helicone.ai) — Passthrough billing at **0% markup** with observability bundled.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Stars auto-refresh daily. ✅ built-in · ➕ via plugin/paid tier · ❌ not av
 | [OpenRouter](https://openrouter.ai) | SaaS marketplace | — | Commercial | ✅ 400+ | ✅ | ✅ | ➕ | ✅ |
 | [Vercel AI Gateway](https://vercel.com/ai-gateway) | SaaS (0% markup) | — | Commercial | ✅ 100s | ✅ | ❌ | ❌ | ✅ |
 | [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) | SaaS control plane | — | Commercial (free tier) | ✅ | ✅ dynamic | ✅ | ✅ | ✅ budgets |
-| [lxg2it ModelRouter](https://lxg2it.com) | OSS router + SaaS | <!--s:lxg2it/modelrouter-core-->⭐ 0<!--/s--> | MIT | ✅ 7+ | ✅ tiered fallback | ➕ | ❌ | ✅ |
+| [lxg2it ModelRouter](https://api.lxg2it.com) | OSS router + SaaS | <!--s:lxg2it/modelrouter-core-->⭐ 0<!--/s--> | MIT | ✅ 7+ | ✅ tiered fallback | ➕ | ❌ | ✅ |
 
 ¹ LiteLLM core is MIT; the repo contains a separately licensed enterprise directory.
 
@@ -129,7 +129,7 @@ Stars auto-refresh daily. ✅ built-in · ➕ via plugin/paid tier · ❌ not av
 - [OpenRouter](https://openrouter.ai) — The dominant model marketplace: 400+ models behind one OpenAI-compatible API, pay-as-you-go with automatic failover; ~5.5% fee when buying credits. $113M Series B (May 2026), ~8M users.
 - [Vercel AI Gateway](https://vercel.com/ai-gateway) — Hundreds of models at **provider list price (0% markup)**, $5/month free credits, zero-data-retention option; pairs naturally with the AI SDK.
 - [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) — Free control plane in front of your own provider keys: caching, dynamic routing, unified billing, and dollar-denominated spend limits (2026 beta).
-- [lxg2it ModelRouter](https://github.com/lxg2it/modelrouter-core) — Open-source, self-hostable model router with a hosted API at [api.lxg2it.com](https://api.lxg2it.com). Free tier, $1/month paid tier. 7+ providers (Anthropic, OpenAI, Google, Cerebras, Groq, Grok, GLM) behind one OpenAI-compatible API with **tiered automatic fallback** — define tiers by capability, router auto-selects cheapest available. **0% markup on Anthropic models** (cheapest hosted access to Claude Opus 4.8). No affiliate fees, no VC.
+- [lxg2it ModelRouter](https://api.lxg2it.com) — Open-source, self-hostable model router (also on [GitHub](https://github.com/lxg2it/modelrouter-core)). Free tier, $1/month paid tier. 7+ providers (Anthropic, OpenAI, Google, Cerebras, Groq, Grok, GLM) behind one OpenAI-compatible API with **tiered automatic fallback** — define tiers by capability, router auto-selects cheapest available. **0% markup on Anthropic models** (cheapest hosted access to Claude Opus 4.8). No affiliate fees, no VC.
 - [Requesty](https://requesty.ai) — EU-friendly OpenRouter alternative: 400+ models, sub-20ms failover, ~5% markup.
 - [Eden AI](https://www.edenai.co) — Unified API for 500+ models plus vision/OCR/speech; EU-based, ~5.5% platform fee.
 - [Helicone AI Gateway (cloud)](https://www.helicone.ai) — Passthrough billing at **0% markup** with observability bundled.


### PR DESCRIPTION
## What

Adds [lxg2it ModelRouter](https://github.com/lxg2it/modelrouter-core) to the Cost-first section.

## Why it fits

- **Free tier + $1/month paid** — cheapest hosted access to frontier models
- **0% markup on Anthropic** — passes through Claude Opus 4.8 at cost (no other hosted gateway does this)
- **Tiered automatic fallback** — define capability tiers, router auto-selects cheapest available model
- **7+ providers**: Anthropic, OpenAI, Google, Cerebras, Groq, Grok, GLM
- **Open-source (MIT)** — self-hostable, transparent
- **No VC, no affiliate fees** — bootstrapped

## Changes

- Quick comparison table: added row
- Decision tree: added to cheapest-access branch
- Comparison table: added row (⭐ 0, MIT, 7+ providers, tiered fallback)
- Cost-first section: full entry with description

Built by a single developer who got tired of OpenRouter markup on Anthropic models. Hosted at api.lxg2it.com.