### PR TITLE
Add fak (agent tool firewall) to MCP & agent gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Stars auto-refresh daily. ✅ built-in · ➕ via plugin/paid tier · ❌ not av
 - [Obot](https://github.com/obot-platform/obot) <!--s:obot-platform/obot-->⭐ 841<!--/s--> — Open-source agent platform with an MCP gateway for governing tool access.
 - [Director](https://github.com/fdmtl/director) <!--s:fdmtl/director-->⭐ 479<!--/s--> — Middleware to run, secure and observe MCP servers behind one connection.
 - [Lasso MCP Gateway](https://github.com/lasso-security/mcp-gateway) <!--s:lasso-security/mcp-gateway-->⭐ 376<!--/s--> — Security-first MCP gateway: plugin guardrails, secret masking, threat detection.
+- [fak](https://github.com/anthony-chaudhary/fak) <!--s:anthony-chaudhary/fak-->⭐ 0<!--/s--> — Single static Go binary fronting OpenAI/Anthropic/MCP backends (Ollama, vLLM, SGLang, cloud): a default-deny capability allow-list adjudicates every tool call, suspicious tool results are quarantined out of the model’s context, plus bearer/`x-api-key` auth, an `X-Trace-Id` audit trail and Prometheus `/metrics` — zero external dependencies. Apache-2.0.
 - [Pomerium](https://github.com/pomerium/pomerium) <!--s:pomerium/pomerium-->⭐ 4.9k<!--/s--> — Identity-aware access proxy with MCP support: policy-based auth in front of MCP servers.
 
 ## 🔧 More by capability (cross-cutting)


### PR DESCRIPTION
## What

Adds **[fak](https://github.com/anthony-chaudhary/fak)** to the **🤖 MCP & agent gateways** section.

## Why it fits this list (and that section)

fak is a single static Go binary that sits *on the request path* in front of any OpenAI-compatible / Anthropic / MCP backend (Ollama, vLLM, SGLang, or a cloud endpoint) — `fak serve` is the gateway. It's not an SDK wrapper or a chat UI, and it doesn't try to be a token engine; it owns the governance band that the engines leave open. That maps directly onto the section's pain point — *"Agents call tools now — govern MCP traffic like you govern APIs."*

Its differentiator from the routing-first gateways already on the list (LiteLLM, Portkey, Bifrost) is the **security posture**, which is why I placed it next to the other security-first MCP gateway (Lasso):

- **Default-deny capability allow-list** — every tool call is adjudicated before it runs; an irreversible action is refused by *structure*, not by catching an attack, so it fails closed.
- **Tool-result quarantine** — suspicious tool *results* are held out of the model's context (prompt-injection / tool-poisoning containment), addressing the OWASP Agentic and MCP Top-10 risks.
- **Operational surface** — bearer / `x-api-key` auth, an `X-Trace-Id` audit trail, and Prometheus `/metrics`, all in one process with **zero external dependencies** (Go standard library only).

## Inclusion criteria

- ✅ Actual gateway/proxy on the request path (`fak serve` fronts the backend)
- ✅ Publicly available, open source (Apache-2.0)
- ✅ Active (the repo is under active development)

## Honest disclosure

fak is a young project with a low star count — I'm the author. I've kept the description to what's measurably shipped and flagged the security/governance angle rather than overclaiming throughput (it explicitly does *not* compete with vLLM/SGLang on tokens). The star span uses your `<!--s:owner/repo-->` convention so your CI will refresh it. Happy to adjust the wording, trim the entry, or move it to **Self-hosted open source** if you'd prefer it there.
