### PR TITLE
add RouteScope to Cost-first: cheapest multi-model access

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Stars auto-refresh daily. ✅ built-in · ➕ via plugin/paid tier · ❌ not av
 
 - [OpenRouter](https://openrouter.ai) — The dominant model marketplace: 400+ models behind one OpenAI-compatible API, pay-as-you-go with automatic failover; ~5.5% fee when buying credits. $113M Series B (May 2026), ~8M users.
 - [Vercel AI Gateway](https://vercel.com/ai-gateway) — Hundreds of models at **provider list price (0% markup)**, $5/month free credits, zero-data-retention option; pairs naturally with the AI SDK.
+- [RouteScope](https://www.routescope.ai/?utm_source=GitHub&campaignid=2e57a17293494ded8db2b478dbd09188&utm_term=github) — Unified AI model aggregation & distribution gateway. Cross-format conversion of 100+ LLMs into OpenAI/Claude/Gemini-compatible interfaces. Single API key, centralized dashboard, prepaid credits from $5, no monthly commitment.
 - [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) — Free control plane in front of your own provider keys: caching, dynamic routing, unified billing, and dollar-denominated spend limits (2026 beta).
 - [Requesty](https://requesty.ai) — EU-friendly OpenRouter alternative: 400+ models, sub-20ms failover, ~5% markup.
 - [Eden AI](https://www.edenai.co) — Unified API for 500+ models plus vision/OCR/speech; EU-based, ~5.5% platform fee.


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs to one project each for easy review. -->

## What does this PR do?

- [ ] Adds a project · [ ] Fixes an entry · [ ] Updates data/eval · [ ] Other

**Project / change:**

## Checklist

- [ ] Entry follows the format in [CONTRIBUTING.md](../CONTRIBUTING.md) and sits in the right pain-point section
- [ ] Mirrored in **both** `README.md` and `README.zh-CN.md`
- [ ] Description is factual and neutral (no marketing superlatives)
- [ ] If I touched `scripts/`, `python -m unittest discover -s scripts -p 'test_*.py'` passes
- [ ] If I edited `data/models.json` pricing, I ran `python scripts/cost_calc.py` so the cost tables match

## Notes for the maintainer

<!-- anything else worth knowing -->
