### PR TITLE
Add Standard Compute to Cost-first (flat-rate unlimited, OpenAI-compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ _Pain point: "I want many models for the least money and zero ops."_
 - [OpenRouter](https://openrouter.ai) — The dominant model marketplace: 400+ models behind one OpenAI-compatible API, pay-as-you-go with automatic failover; ~5.5% fee when buying credits. $113M Series B (May 2026), ~8M users.
 - [Vercel AI Gateway](https://vercel.com/ai-gateway) — Hundreds of models at **provider list price (0% markup)**, $5/month free credits, zero-data-retention option; pairs naturally with the AI SDK.
 - [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) — Free control plane in front of your own provider keys: caching, dynamic routing, unified billing, and dollar-denominated spend limits (2026 beta).
+- [Standard Compute](https://standardcompute.com) — Flat-rate unlimited compute behind one OpenAI-compatible endpoint (from $9/mo, no per-token billing); plans differ by execution speed — sustained heavy use is paced rather than rate-limited (no 429s). Single `standardcompute` model id auto-routes to frontier models. Not self-hostable.
 - [Requesty](https://requesty.ai) — EU-friendly OpenRouter alternative: 400+ models, sub-20ms failover, ~5% markup.
 - [Eden AI](https://www.edenai.co) — Unified API for 500+ models plus vision/OCR/speech; EU-based, ~5.5% platform fee.
 - [Helicone AI Gateway (cloud)](https://www.helicone.ai) — Passthrough billing at **0% markup** with observability bundled.


### PR DESCRIPTION
Adds Standard Compute to the Cost-first section, matching the existing entry format.

Facts, verifiable: flat-rate subscription tiers ($9/$39/$99/$399/mo) that differ by execution speed rather than usage caps; OpenAI-compatible endpoint (`https://api.stdcmpt.com/v1`); single `standardcompute` model id that auto-routes to frontier models; sustained heavy use is paced gradually instead of returning 429s. Not self-hostable, no affiliate links.

Disclosure: I run Standard Compute. Happy to adjust wording to house style.