### PR TITLE
Add Shim to Enterprise & compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ _Pain point: "Audit logs, PII redaction, RBAC, on-prem, and the EU AI Act (enfor
 - [Red Hat Connectivity Link](https://www.redhat.com/en/technologies/cloud-computing/connectivity-link) - Kubernetes-native gateway (built on the Kuadrant project, successor to 3scale) unifying AI gateway, API management and multicluster connectivity; powers OpenShift AI Models-as-a-Service as the front door governing external and self-hosted LLM endpoints.
 - [Sensedia AI Gateway](https://www.sensedia.com/product/ai-gateway) - Gartner-recognized APIM vendor's agnostic AI gateway governing LLMs, MCP servers and AI agents with multi-model routing, guardrails, cost controls and observability across a multi-cloud control plane.
 - [Ambassador Edge Stack](https://www.getambassador.io/products/edge-stack/api-gateway) - Envoy-based, Kubernetes-native API gateway (OSS core [emissary-ingress](https://github.com/emissary-ingress/emissary) <!--s:emissary-ingress/emissary-->⭐ 4.5k<!--/s-->) whose AI Gateway layer adds LLM-provider routing, token rate-limiting and fallback — a peer to Kong/Tyk/APISIX in the API-vendor cohort.
+- [Shim](https://getshim.tech) - Compliance-oriented AI gateway: Presidio-based PII redaction including Turkish TCKN/VKN identifiers, a tamper-evident hash-chain audit log with daily Merkle anchors for EU AI Act and KVKK evidence, plus semantic caching and per-tag cost attribution.
 
 ## 🌐 First-party gateways (cloud & model vendors)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -272,6 +272,7 @@ _生态里被问得最多的问题之一，而网上的答案大多已过期。�
 - [Red Hat Connectivity Link](https://www.redhat.com/en/technologies/cloud-computing/connectivity-link) — 基于 Kuadrant 项目（3scale 的继任者）的 Kubernetes 原生网关，统一 AI 网关、API 管理与多集群连接；作为 OpenShift AI「模型即服务」的前门，治理外部与自托管 LLM 端点。
 - [Sensedia AI Gateway](https://www.sensedia.com/product/ai-gateway) — Gartner 认可的 APIM 厂商出品的中立 AI 网关，以多模型路由、护栏、成本控制与可观测治理 LLM、MCP server 与 AI Agent，构成多云控制面。
 - [Ambassador Edge Stack](https://www.getambassador.io/products/edge-stack/api-gateway) — 基于 Envoy 的 Kubernetes 原生 API 网关（开源内核 [emissary-ingress](https://github.com/emissary-ingress/emissary) <!--s:emissary-ingress/emissary-->⭐ 4.5k<!--/s-->），其 AI Gateway 层增加 LLM 厂商路由、token 限流与兜底——API 厂商阵营里 Kong/Tyk/APISIX 的同类。
+- [Shim](https://getshim.tech) — 面向合规的 AI 网关：基于 Presidio 的 PII 脱敏（含土耳其 TCKN/VKN 标识符）、带每日 Merkle 锚点的防篡改哈希链审计日志（用于欧盟 AI Act 与 KVKK 举证），并提供语义缓存与按标签的成本归集。
 
 ## 🌐 原厂直连（云厂商/模型厂商）
 


### PR DESCRIPTION
## What does this PR do?

- [x] Adds a project · [ ] Fixes an entry · [ ] Updates data/eval · [ ] Other

**Project / change:** [Shim](https://getshim.tech) added to `🏢 Enterprise & compliance`, mirrored in `README.zh-CN.md`.

Why this section: the stated pain point is "audit logs, PII redaction, RBAC, on-prem, and the EU AI Act". Shim sits on the request path as an OpenAI-compatible endpoint in front of OpenAI/Anthropic/Gemini/Ollama. Its differentiator against the entries already in this section is the local-regime side of PII — Turkish TCKN/VKN and TR IBAN recognizers layered on Presidio, which the general-purpose PII layers here don't cover — plus a hash-chained audit log with daily Merkle anchors, built as auditor evidence rather than observability.

## Checklist

- [x] Entry follows the format in [CONTRIBUTING.md](../CONTRIBUTING.md) and sits in the right pain-point section
- [x] Mirrored in **both** `README.md` and `README.zh-CN.md`
- [x] Description is factual and neutral (no marketing superlatives)
- [ ] `scripts/` not touched
- [ ] `data/models.json` not touched

## Notes for the maintainer

Disclosure: I work on Shim, so please read this as a self-submission.

No star marker on the entry — it's a commercial product with public docs and a free tier rather than a public repo, so per CONTRIBUTING the marker is omitted, and it isn't added to `release_tracked_repos` for the same reason.

The zh-CN line is a rough translation; happy for you to polish or rewrite it. If you'd rather hold the entry until there's independent evidence, that's completely fair — just close this.