### PR TITLE
Add SandBase CLI to MCP gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ _Pain point: "Agents call tools now — govern MCP traffic like you govern APIs.
 - [Nexus (Grafbase)](https://github.com/Nexus-Router/nexus) <!--s:Nexus-Router/nexus-->⭐ 434<!--/s--> - Rust AI router from Grafbase that aggregates MCP servers (STDIO/SSE/HTTP) and LLM providers behind one endpoint with context-aware fuzzy tool search, OAuth2/TLS security, rate limiting and OpenTelemetry.
 - [Pomerium](https://github.com/pomerium/pomerium) <!--s:pomerium/pomerium-->⭐ 5k<!--/s--> - Identity-aware access proxy with MCP support: policy-based auth in front of MCP servers.
 - [Open Connector](https://github.com/oomol-lab/open-connector) <!--s:oomol-lab/open-connector-->⭐ 4.8k<!--/s--> - Open-source auth gateway (Apache-2.0, OOMOL Lab) connecting AI agents to 1000+ SaaS providers through SDK, CLI, MCP, HTTP and OpenAPI — it governs agent→SaaS tool credentials and access rather than LLM completion traffic.
+- [SandBase CLI](https://github.com/sandbaseai/cli) <!--s:sandbaseai/cli-->⭐ 20<!--/s--> - Apache-2.0 CLI and local MCP bridge that configures 25 AI clients to discover, inspect and call 2,000+ AI models and APIs through one SandBase account.
 - [toolport](https://github.com/tsouth89/toolport) <!--s:tsouth89/toolport-->⭐ 181<!--/s--> - Local-first MCP gateway (MIT): one port for every tool and every AI client, with lazy tool discovery (~90% token savings, per its docs), tool integrity checks + quarantine, and secrets kept in the OS keychain.
 
 ## 🔧 More by capability (cross-cutting)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -420,6 +420,7 @@ _生态里被问得最多的问题之一，而网上的答案大多已过期。�
 - [Nexus (Grafbase)](https://github.com/Nexus-Router/nexus) <!--s:Nexus-Router/nexus-->⭐ 434<!--/s--> — Grafbase 出品的 Rust AI 路由器，把 MCP server（STDIO/SSE/HTTP）与 LLM 厂商聚合到一个端点之后，带上下文感知的模糊工具搜索、OAuth2/TLS 安全、限流与 OpenTelemetry。
 - [Pomerium](https://github.com/pomerium/pomerium) <!--s:pomerium/pomerium-->⭐ 5k<!--/s--> — 身份感知访问代理，新增 MCP 支持：在 MCP server 前做基于策略的鉴权。
 - [Open Connector](https://github.com/oomol-lab/open-connector) <!--s:oomol-lab/open-connector-->⭐ 4.8k<!--/s--> — 开源鉴权网关（Apache-2.0，OOMOL Lab），通过 SDK、CLI、MCP、HTTP 与 OpenAPI 把 AI Agent 接到 1000+ SaaS 服务——治理的是 Agent→SaaS 的工具凭证与访问，而非 LLM 补全流量。
+- [SandBase CLI](https://github.com/sandbaseai/cli) <!--s:sandbaseai/cli-->⭐ 20<!--/s--> — Apache-2.0 CLI 与本地 MCP bridge，可配置 25 个 AI 客户端，通过一个 SandBase 账号发现、检查并调用 2,000+ 个 AI 模型与 API。
 - [toolport](https://github.com/tsouth89/toolport) <!--s:tsouth89/toolport-->⭐ 181<!--/s--> — 本地优先的 MCP 网关（MIT）：一个端口收口所有工具与 AI 客户端，带懒加载工具发现（按其文档约省 90% token）、工具完整性校验 + 隔离，密钥存放在系统钥匙串。
 
 ## 🔧 更多按能力分（横切关注点）


### PR DESCRIPTION
## What this adds

- Adds SandBase CLI as one project in the MCP & agent gateways section.
- Updates both English and Chinese READMEs with mirrored, factual descriptions.
- Leaves pricing data and automation scripts unchanged.

## Validation

- `python3 -m unittest discover -s scripts -p "test_*.py"` — 274 tests passed.
- `git diff --check` — passed.

## Disclosure

I am affiliated with SandBase. AI assistance was used to prepare and validate this contribution.

This supersedes #54, which was closed by the SandBase account during an earlier fork-cleanup pass; it had no maintainer rejection, review, or requested changes.