### PR TITLE
Add SandBase CLI gateway entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ _Pain point: "Agents call tools now — govern MCP traffic like you govern APIs.
 - [Pomerium](https://github.com/pomerium/pomerium) <!--s:pomerium/pomerium-->⭐ 5k<!--/s--> - Identity-aware access proxy with MCP support: policy-based auth in front of MCP servers.
 - [Open Connector](https://github.com/oomol-lab/open-connector) <!--s:oomol-lab/open-connector-->⭐ 5.3k<!--/s--> - Open-source auth gateway (Apache-2.0, OOMOL Lab) connecting AI agents to 1000+ SaaS providers through SDK, CLI, MCP, HTTP and OpenAPI — it governs agent→SaaS tool credentials and access rather than LLM completion traffic.
 - [toolport](https://github.com/tsouth89/toolport) <!--s:tsouth89/toolport-->⭐ 188<!--/s--> - Local-first MCP gateway (MIT): one port for every tool and every AI client, with lazy tool discovery (~90% token savings, per its docs), tool integrity checks + quarantine, and secrets kept in the OS keychain.
+- [SandBase CLI](https://github.com/sandbaseai/cli) <!--s:sandbaseai/cli-->⭐ 66<!--/s--> - Provider-agnostic CLI and local MCP bridge connecting 25 AI clients to SandBase's catalog of 2,000+ models and APIs, with OAuth onboarding and rollback.
 
 ## 🔧 More by capability (cross-cutting)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -428,6 +428,7 @@ _生态里被问得最多的问题之一，而网上的答案大多已过期。�
 - [Pomerium](https://github.com/pomerium/pomerium) <!--s:pomerium/pomerium-->⭐ 5k<!--/s--> — 身份感知访问代理，新增 MCP 支持：在 MCP server 前做基于策略的鉴权。
 - [Open Connector](https://github.com/oomol-lab/open-connector) <!--s:oomol-lab/open-connector-->⭐ 5.3k<!--/s--> — 开源鉴权网关（Apache-2.0，OOMOL Lab），通过 SDK、CLI、MCP、HTTP 与 OpenAPI 把 AI Agent 接到 1000+ SaaS 服务——治理的是 Agent→SaaS 的工具凭证与访问，而非 LLM 补全流量。
 - [toolport](https://github.com/tsouth89/toolport) <!--s:tsouth89/toolport-->⭐ 188<!--/s--> — 本地优先的 MCP 网关（MIT）：一个端口收口所有工具与 AI 客户端，带懒加载工具发现（按其文档约省 90% token）、工具完整性校验 + 隔离，密钥存放在系统钥匙串。
+- [SandBase CLI](https://github.com/sandbaseai/cli) <!--s:sandbaseai/cli-->⭐ 66<!--/s--> — 与提供商无关的 CLI 和本地 MCP 桥接，连接 25 个 AI 客户端到 SandBase 的 2,000+ 模型与 API 目录，支持 OAuth 引导和回滚。
 
 ## 🔧 更多按能力分（横切关注点）
 

--- a/data/projects.json
+++ b/data/projects.json
@@ -100,6 +100,7 @@
     "kittors/CliRelay",
     "caozhiyuan/copilot-api",
     "beizhu-1209/AIHelms",
-    "LianjiaTech/bella-openapi"
+    "LianjiaTech/bella-openapi",
+    "sandbaseai/cli"
   ]
 }


### PR DESCRIPTION
## Add SandBase CLI to MCP & agent gateways

This adds SandBase CLI to both language READMEs and release tracking, following the repository's requested format. It is an active open-source CLI/local MCP bridge that sits on the agent request path and connects supported clients to a hosted model/API catalog.

- Repository: https://github.com/sandbaseai/cli
- License: Apache-2.0
- Current release: v0.1.17
- Current repository stars: 66 (the marker is refreshed by CI)
- `git diff --check` passes.

The full test suite was run; two existing shallow-clone date tests cannot resolve commit metadata in this depth-1 checkout, while no scripts were changed.
