### PR TITLE
docs: add SandBase CLI gateway entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ _Stars are cumulative; they never go down when a project stops shipping. Every t
 - [Vercel AI Gateway](https://vercel.com/ai-gateway) - Hundreds of models at **provider list price (0% markup)**, $5/month free credits, zero-data-retention option; pairs naturally with the AI SDK.
 - [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) - Free control plane in front of your own provider keys: caching, dynamic routing, unified billing, and dollar-denominated spend limits (2026 beta).
 - [Requesty](https://requesty.ai) - EU-friendly OpenRouter alternative: 400+ models, sub-20ms failover, ~5% markup.
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Open-source CLI and MCP bridge exposing an OpenAI-compatible endpoint for 2,000+ AI models, with usage-based billing and a free plan. New and unverified (self-submitted); confirm model fidelity and data handling before production use.
 - [Eden AI](https://www.edenai.co) - Unified API for 500+ models plus vision/OCR/speech; EU-based, ~5.5% platform fee.
 - [Helicone AI Gateway (cloud)](https://www.helicone.ai) - Passthrough billing at **0% markup** with observability bundled. Acquired by Mintlify (2026-03) and in maintenance mode — fine to use today, but weigh the roadmap risk.
 - [GPT-Load](https://github.com/tbphp/gpt-load) <!--s:tbphp/gpt-load-->⭐ 6.3k<!--/s--> - High-performance Go proxy that rotates pools of API keys across channels to maximize quota usage.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -225,6 +225,7 @@ _星数是累计的:项目停更了它也不会往下掉。下面这些被跟踪
 - [Vercel AI Gateway](https://vercel.com/ai-gateway) — 数百模型按**厂商原价（0 加价）**计费，每月 $5 免费额度，可选零数据保留；与 AI SDK 天然搭配。
 - [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) — 免费控制面套在你自己的厂商 Key 之上：缓存、动态路由、统一账单、美元计价的预算上限（2026 公测）。
 - [Requesty](https://requesty.ai) — 面向欧盟的 OpenRouter 替代：400+ 模型、20ms 内故障转移、约 5% 加价。
+- [SandBase CLI](https://github.com/sandbaseai/cli) — 开源 CLI 与 MCP 桥接，通过 OpenAI 兼容端点接入 2,000+ 个 AI 模型，按量计费并提供免费计划。较新且未经核实（自荐）；投入生产前请自行验证模型保真度与数据处理方式。
 - [Eden AI](https://www.edenai.co) — 统一 API 接入 500+ 模型及视觉/OCR/语音；欧盟公司，平台费约 5.5%。
 - [Helicone AI Gateway（云版）](https://www.helicone.ai) — **0 加价**直通计费，可观测能力打包赠送。
 - [GPT-Load](https://github.com/tbphp/gpt-load) <!--s:tbphp/gpt-load-->⭐ 6.3k<!--/s--> — Go 写的高性能多渠道密钥轮询代理，把每把 Key 的额度榨干。


### PR DESCRIPTION
## Summary
- Add SandBase CLI to the cost-first gateway section in both English and Chinese READMEs
- Describe the canonical CLI/MCP bridge, OpenAI-compatible endpoint, 2,000+ models, and usage-based/free-plan access
- Mark the entry as new, unverified, and self-submitted per the project contribution policy

## Fit
The project sits on the request path as a hosted OpenAI-compatible gateway and is directly relevant to this list's multi-model access scope. The description is deliberately neutral and asks readers to verify fidelity and data handling before production use.

Canonical project: https://github.com/sandbaseai/cli
Documentation: https://docs.sandbase.ai