### PR TITLE
Add Gonka Broker (cost-first)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ _Stars are cumulative; they never go down when a project stops shipping. Every t
 - [freellmapi](https://github.com/tashfeenahmed/freellmapi) <!--s:tashfeenahmed/freellmapi-->⭐ 23.4k<!--/s--> - OpenAI-compatible proxy (MIT) that stacks the free tiers of 28 LLM providers behind one `/v1` endpoint — smart routing, automatic failover, per-key quota tracking, encrypted key storage. ⚠️ Stacking provider free quotas behind one endpoint can carry provider-ToS / account-ban risk — the repo itself says "personal experimentation only" — and the operator sells a paid live-catalog subscription ($19/yr; the router itself stays MIT, self-hosted, on your own keys).
 - [AIMLAPI](https://aimlapi.com) - One OpenAI/Anthropic-compatible endpoint fronting 400+ models (chat, image, video, audio, embeddings); prepaid, OpenRouter-style aggregator.
 - [Novita AI](https://novita.ai) - Unified API to 200+ open-source models (DeepSeek/Qwen/Llama…) with load balancing, autoscaling and failover; also a GPU cloud.
+- [Gonka Broker](https://gonkabroker.com) - OpenAI- and Anthropic-compatible gateway to open-weight models (MiniMax, Kimi, DeepSeek, ...) served on the decentralized Gonka GPU network; flat pay-as-you-go pricing with input and output at the same rate, locked in at top-up, paid by card with no crypto wallet.
 - [Glama Gateway](https://glama.ai/ai/gateway) - OpenAI-compatible gateway to 100+ models with consolidated billing, caching and logging (OSS core [glama-ai/lightport](https://github.com/glama-ai/lightport)).
 
 <details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -231,6 +231,7 @@ _星数是累计的:项目停更了它也不会往下掉。下面这些被跟踪
 - [freellmapi](https://github.com/tashfeenahmed/freellmapi) <!--s:tashfeenahmed/freellmapi-->⭐ 23.4k<!--/s--> — OpenAI 兼容代理（MIT），把 28 家厂商的免费额度叠加在一个 `/v1` 端点之后——智能路由、自动故障转移、按 Key 额度追踪、密钥加密存储。⚠️ 把各家免费额度池化到一个端点可能触碰厂商 ToS / 封号风险——仓库自己就标注"仅供个人实验"——运营方另售付费实时模型目录订阅（$19/年；路由器本体始终 MIT、自托管、用自己的 Key）。
 - [AIMLAPI](https://aimlapi.com) — 一个 OpenAI/Anthropic 兼容端点打通 400+ 模型（对话/图像/视频/音频/向量）；预付费，OpenRouter 式聚合器。
 - [Novita AI](https://novita.ai) — 统一 API 接入 200+ 开源模型（DeepSeek/Qwen/Llama…），自带负载均衡、弹性扩缩与故障转移；另有 GPU 云。
+- [Gonka Broker](https://gonkabroker.com) — 兼容 OpenAI 与 Anthropic 的网关，接入部署在去中心化 Gonka GPU 网络上的开源权重模型（MiniMax、Kimi、DeepSeek, ...）；扁平按量计费、输入与输出同价、充值时锁定单价，刷卡支付、无需加密钱包。
 - [Glama Gateway](https://glama.ai/ai/gateway) — OpenAI 兼容网关，接入 100+ 模型，统一账单、缓存与日志（开源内核 [glama-ai/lightport](https://github.com/glama-ai/lightport)）。
 
 <details>


### PR DESCRIPTION
Adds Gonka Broker to the Cost-first section.

What it is: an OpenAI- and Anthropic-compatible gateway to open-weight models (MiniMax, Kimi,
DeepSeek) served on the decentralized Gonka GPU network. Flat pay-as-you-go pricing, input and
output at the same rate, locked in at top-up, paid by card with no crypto wallet.

Inclusion criteria:
1. Gateway on the request path (single OpenAI-/Anthropic-compatible endpoint), not an SDK wrapper
   or chat UI.
2. Publicly available commercial product with public docs (https://gonkabroker.com,
   pricing at https://gonkabroker.com/gonka-api-pricing/, live models and prices at
   https://proxy.gonkabroker.com/v1/models).
3. Active (models and pricing updated continuously).
4. Not a stolen-quota or reverse-engineered relay: it serves open-weight models on its own network,
   not resold frontier-model quota through an upstream account. Happy for you to run
   scripts/canary_check.py against it.

Placed next to Novita AI (open-weight models on own infrastructure). Added to both README.md and
README.zh-CN.md.