### PR TITLE
Add OrcaReplay under 📊 Observability & cost tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ _Pain point: "Who spent what, on which model, and why did quality drop?"_
 - [Respan](https://www.respan.ai/ai-gateway) (ex–Keywords AI) - One endpoint to 250+ models with routing/fallback/caching, plus built-in observability and evals.
 - [claude-tap](https://github.com/liaohch3/claude-tap) <!--s:liaohch3/claude-tap-->⭐ 3.2k<!--/s--> - MIT local intercepting proxy and trace viewer for coding-agent traffic (Claude Code, Codex CLI, Gemini CLI, Cursor CLI, OpenCode, Kimi, Pi, Hermes): the exact requests, responses and tool calls your agent sends. Wider agent coverage than ccglass; debugging-first rather than spend-first.
 - [ccglass](https://github.com/jianshuo/ccglass) <!--s:jianshuo/ccglass-->⭐ 787<!--/s--> - Local proxy + web dashboard (MIT) that shows exactly what your coding agent (Claude Code, Codex, Kimi) sends to the model.
+- [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) <!--s:Continuum-AI-Corp/OrcaReplay-->⭐ 173<!--/s--> - Apache-2.0 local proxy that records coding-agent traffic and, unlike a viewer, serves the recording back: the same run re-executes with no model called, or forks from a checkpoint onto other models with a verify command as the verdict.
 
 ### 🚢 Kubernetes-native & inference infra
 


### PR DESCRIPTION
Adds OrcaReplay to **📊 Observability & cost tracking**, next to `claude-tap` and `ccglass`.

**Disclosure: I work on it.** Apache-2.0, free, no paid tier.

## Why here and not in the gateway sections

It is not a gateway — it does not route, load-balance or fall back, and nobody should pick it instead of LiteLLM or Portkey. It belongs in this subsection for the same reason `claude-tap` and `ccglass` do: it is a local proxy that captures coding-agent traffic.

## What it adds that those two do not

Both are viewers — they show you the traffic. OrcaReplay keeps the **verbatim request and response bytes**, which costs disk and buys one thing: the recording can be served back.

```console
$ orca record claude -- -p "fix the failing test"
$ orca replay last
info replaying exchanges=8 egress=blocked
info replay.done reused=8/8 exact=8 divergences=0 exit=0
```

The agent runs again against the recording, with no provider called and no tokens spent. From any checkpoint the run can also continue **live** on a different model — `orca compare last --models a,b,c --verify "npm test"` restores the git tree, runs each model in its own worktree, and the verify command's exit code is the verdict.

So on the pain point this section names — *"why did quality drop?"* — it answers by re-running the same work rather than by charting it after the fact.

## Cost tracking, since that is half the section

Token counts come from the provider's own response and land per exchange in the trace, with a pricing table for cost. But the honest framing is the other direction: the reason it belongs under cost is that **replaying is free**, so the usual "re-run it to see what happened" bill goes away.

## Verified

Nine harness adapters, each with a fixture pinning the exact variables it sets. Three driven end to end against the real thing: Claude Code, goose 1.49.0 (`1 failed` → agent fixes it → `1 passed`, then strict replay `reused=8/8 exact=8`), and OpenHands 1.11.0. Frameworks are checked in CI against a stub origin — LangGraph, LiteLLM, browser-use, the OpenAI SDKs — recorded, origin killed, replayed, numbers asserted.

## One scope note, since this list is careful about them

`egress=blocked` means **model-provider egress**. Replay still executes recorded tool calls for real, so a recorded `curl` reaches the network. It is not a sandbox, and the README says so.

Star count in the entry is the real 173, not rounded up. Happy to reword or move it.
