### PR TITLE
Add Speakeasy MCP Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ _Pain point: "Domestic models (Qwen/DeepSeek/GLM/Kimi), CNY payment, key distrib
 _Pain point: "Agents call tools now — govern MCP traffic like you govern APIs."_ The newest category (2025–2026).
 
 - [agentgateway](https://github.com/agentgateway/agentgateway) <!--s:agentgateway/agentgateway-->⭐ 4.8k<!--/s--> - Linux Foundation proxy for agentic traffic (LF Projects, per its own CHARTER — not a CNCF-hosted project): MCP governance and agent-to-agent (A2A) communication.
+- [Speakeasy MCP Gateway](https://www.speakeasy.com/product/mcp-gateway) - Managed MCP gateway that routes agents and tool calls through one governed entry point, with SSO, role-based access, runtime guardrails, and audit logs.
 - [TrustGate](https://docs.neuraltrust.ai/trustgate) <!--s:NeuralTrust/TrustGate-->⭐ 9<!--/s--> - Self-hosted Go gateway whose MCP plane aggregates upstream MCP servers behind one endpoint, sharing the tenancy, auth and policy model of its LLM proxy — one governance surface for both traffic types rather than two.
 - [Lunar.dev MCPX](https://lunar.dev) <!--s:TheLunarCompany/lunar-->⭐ 491<!--/s--> - Gateway for managing MCP server consumption.
 - [Tetrate Agent Router Service](https://tetrate.io/products/tetrate-agent-router-service) - Managed Envoy AI Gateway fleet: LLM + MCP gateway with guardrails (~5% fee).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -405,6 +405,7 @@ _生态里被问得最多的问题之一，而网上的答案大多已过期。�
 *痛点："Agent 开始调工具了——像治理 API 一样治理 MCP 流量。"* 2025–2026 最新品类。
 
 - [agentgateway](https://github.com/agentgateway/agentgateway) <!--s:agentgateway/agentgateway-->⭐ 4.8k<!--/s--> — Linux Foundation 旗下的 Agent 流量代理（据其 CHARTER 属 LF Projects，并非 CNCF 托管项目）：MCP 治理与 Agent 间（A2A）通信。
+- [Speakeasy MCP Gateway](https://www.speakeasy.com/product/mcp-gateway) — 托管 MCP 网关，将 Agent 和工具调用汇聚到一个受管控入口，提供 SSO、基于角色的访问控制、运行时护栏和审计日志。
 - [TrustGate](https://docs.neuraltrust.ai/trustgate) <!--s:NeuralTrust/TrustGate-->⭐ 9<!--/s--> — 自托管 Go 网关：MCP 平面把上游 MCP 服务聚合到单一端点，并与其 LLM 代理共享租户、鉴权与策略模型——两类流量共用一套治理面，而不是各搭一套。
 - [Lunar.dev MCPX](https://github.com/TheLunarCompany/lunar) <!--s:TheLunarCompany/lunar-->⭐ 491<!--/s--> — 管理 MCP server 消费的网关。
 - [Tetrate Agent Router Service](https://tetrate.io/products/tetrate-agent-router-service) — 托管 Envoy AI Gateway 集群：LLM + MCP 网关与护栏（约 5% 费率）。


### PR DESCRIPTION
Adds Speakeasy MCP Gateway to MCP & agent gateways in both README language files. It provides a governed MCP entry point with policy enforcement, access controls, inspection, and audit logs. Validation: bash scripts/regen.sh (274 tests, 1 skipped), git diff --check, canonical links.